### PR TITLE
fix: remove obsolete '#[allow(dead_code)]'

### DIFF
--- a/src/emc2101/hw/device_registers.rs
+++ b/src/emc2101/hw/device_registers.rs
@@ -3,8 +3,6 @@
 // (described in section 5 of the data sheet)
 //
 
-// TODO remove this pragma once the implementation is complete and all values are used
-#[allow(dead_code)]
 pub enum DR {
     Its = 0x00,       // internal sensor - temperature
     EtsMsb = 0x01,    // external diode - temperature (high byte)


### PR DESCRIPTION
The pragma is no longer required and can be removed.