### PR TITLE
ci: exclude CHANGELOG.md from linting

### DIFF
--- a/.github/workflows/validate-code.yaml
+++ b/.github/workflows/validate-code.yaml
@@ -25,10 +25,11 @@ jobs:
       - name: identify changed files
         id: changed-files
         uses: tj-actions/changed-files@v46
-        files_ignore:
-          # release-please creates double-newlines which would be flagged
-          # by markdownlint; the easiest fix is to ignore the file entirely
-          - CHANGELOG.md
+        with:
+          files_ignore:
+            # release-please creates double-newlines which would be flagged
+            # by markdownlint; the easiest fix is to ignore the file entirely
+            - CHANGELOG.md
       # https://github.com/actions-rust-lang/setup-rust-toolchain
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/validate-code.yaml
+++ b/.github/workflows/validate-code.yaml
@@ -25,6 +25,10 @@ jobs:
       - name: identify changed files
         id: changed-files
         uses: tj-actions/changed-files@v46
+        files_ignore:
+          # release-please creates double-newlines which would be flagged
+          # by markdownlint; the easiest fix is to ignore the file entirely
+          - CHANGELOG.md
       # https://github.com/actions-rust-lang/setup-rust-toolchain
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/validate-code.yaml
+++ b/.github/workflows/validate-code.yaml
@@ -26,10 +26,10 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v46
         with:
-          files_ignore:
-            # release-please creates double-newlines which would be flagged
-            # by markdownlint; the easiest fix is to ignore the file entirely
-            - CHANGELOG.md
+          # release-please creates double-newlines which would be flagged
+          # by markdownlint; the easiest fix is to ignore the file entirely
+          files_ignore: |
+            CHANGELOG.md
       # https://github.com/actions-rust-lang/setup-rust-toolchain
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
release-please creates consecutive newlines which would be flagged by markdownlint:

```text
markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
Finding: CHANGELOG.md
Linting: 1 file(s)
Summary: 2 error(s)
CHANGELOG.md:5 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
CHANGELOG.md:10 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
```

The easiest fix is to ignore the file entirely.