### PR TITLE
refactor: redesign trait 'I2cBusDevice' to expose generic read/write operations

### DIFF
--- a/examples/esp32-c6/Cargo.lock
+++ b/examples/esp32-c6/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "i2c_devices"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "numtoa",

--- a/examples/esp32-c6/Cargo.toml
+++ b/examples/esp32-c6/Cargo.toml
@@ -65,7 +65,9 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 
 critical-section = "1.2.0"
 static_cell      = "2.1.1"
-i2c_devices = { version = "0.1.0", path = "../..", default-features = false }
+# uses 'any' version to avoid conflicts with release-please
+# (replace with a specific version in real code outside this repository)
+i2c_devices = { version = "*", path = "../..", default-features = false }
 
 
 [profile.dev]

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -265,11 +265,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        // TODO add error handling for write_register_as_u8()
-        let _ = self.i2c_bus.write(da, &[dr, byte]);
-    }
-
     // TODO rename function: write_multiple_registers_as_u8()
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for x in values.iter() {

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -251,10 +251,14 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
         }
     }
 
-    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
-        validate_device_address(da);
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8]) -> Option<[u8; N]> {
+        let mut rb = [0u8; N];
 
-        panic!("read_byte(): function not implemented")
+        // TODO add error handling for read_register_as_u8()
+        let _ = self.i2c_bus.write_read(da, bytes, &mut rb);
+
+        // implicit return
+        Some(rb)
     }
 
     // --------------------------------------------------------------------

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -275,16 +275,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
         }
     }
 
-    fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        let mut rb = [0u8; 1];
-
-        // TODO add error handling for read_register_as_u8()
-        let _ = self.i2c_bus.write_read(da, &[dr], &mut rb);
-
-        // implicit return
-        rb[0]
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         // TODO add error handling for write_register_as_u8()
         let _ = self.i2c_bus.write(da, &[dr, byte]);

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -265,16 +265,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        let mut buf = [0, 1];
-
-        let res = self.i2c_bus.read(da, &mut buf);
-        match res {
-            Ok(_) => Ok(buf[0]),
-            Err(_) => Err(""),
-        }
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         // TODO add error handling for write_register_as_u8()
         let _ = self.i2c_bus.write(da, &[dr, byte]);

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -265,10 +265,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
         }
     }
 
-    fn write_byte(&mut self, da: u8, byte: u8) {
-        let _ = self.i2c_bus.write(da, &[byte]);
-    }
-
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
         let mut rb = [0u8; 1];
 

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -270,31 +270,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
         let _ = self.i2c_bus.write(da, &[dr, byte]);
     }
 
-    // TODO rename function: read_multiple_registers_as_u8()
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
-        let mut rb = [0u8; N];
-
-        // it's a bit overkill to use a loop for two iterations but that way we
-        // avoid code duplication and it opens up the possibility of reading an
-        // arbitrary number of values
-        for (i, register) in dr.iter().enumerate() {
-            let mut v = [0; 1];
-            match self.i2c_bus.write_read(da, &[*register], &mut v) {
-                Ok(_) => {
-                    debug!(
-                        "Successfully read register '{0:#04X}' (value: {1:#04X}).",
-                        dr[i], rb[i]
-                    );
-                    rb[i] = v[0];
-                }
-                Err(reason) => warn!("Failed to read register '{0:#04X}': {reason}", dr[i]),
-            }
-        }
-
-        // implicit return
-        rb
-    }
-
     // TODO rename function: write_multiple_registers_as_u8()
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for x in values.iter() {

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -251,6 +251,12 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/examples/esp32-c6/src/bin/main.rs
+++ b/examples/esp32-c6/src/bin/main.rs
@@ -265,21 +265,6 @@ impl<'a, Dm: esp_hal::DriverMode> i2c_devices::I2cBusDevice for I2cBusDevice<'a,
     // to refactor
     // --------------------------------------------------------------------
 
-    // TODO rename function: write_multiple_registers_as_u8()
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        for x in values.iter() {
-            match self.i2c_bus.write(da, x) {
-                Ok(_) => {
-                    debug!(
-                        "Successfully wrote register '{0:#04X}' (value: {1:#04X}).",
-                        x[0], x[1]
-                    );
-                }
-                Err(reason) => warn!("Failed to read register '{0:#04X}': {reason}", x[0]),
-            }
-        }
-    }
-
     // some functions require a little time to pass
     // the sleep function is hardware-dependent and must be provided by
     // the caller

--- a/examples/rp2040/Cargo.lock
+++ b/examples/rp2040/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "i2c_devices"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "numtoa",

--- a/examples/rp2040/Cargo.toml
+++ b/examples/rp2040/Cargo.toml
@@ -8,8 +8,10 @@ cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
 embedded-hal = "1.0.0"
 embedded_hal_0_2 = { version = "0.2.5", package = "embedded-hal", features = ["unproven"] }
-i2c_devices = { version = "0.1.0", path = "../../", default-features = false }
 log = "0.4.28"
 panic-halt = "1.0.0"
 rp2040-boot2 = "0.3.0"
 rp2040-hal = { version = "0.11.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"] }
+# uses 'any' version to avoid conflicts with release-please
+# (replace with a specific version in real code outside this repository)
+i2c_devices = { version = "*", path = "../..", default-features = false }

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -248,27 +248,6 @@ where
         let _ = self.i2c_bus.write(da, &[dr, byte]);
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
-        let mut rb = [0u8; N];
-
-        for (i, register) in dr.iter().enumerate() {
-            let mut v = [0; 1];
-            match self.i2c_bus.write_read(da, &[*register], &mut v) {
-                Ok(_) => {
-                    debug!(
-                        "Successfully read register '{0:#04X}' (value: {1:#04X}).",
-                        dr[i], rb[i]
-                    );
-                    rb[i] = v[0];
-                }
-                Err(reason) => warn!("Failed to read register '{0:#04X}': {reason:?}", dr[i]),
-            }
-        }
-
-        // implicit return
-        rb
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for x in values.iter() {
             match self.i2c_bus.write(da, x) {

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -253,16 +253,6 @@ where
         }
     }
 
-    fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        let mut rb = [0u8; 1];
-
-        // TODO add error handling for read_register_as_u8()
-        let _ = self.i2c_bus.write_read(da, &[dr], &mut rb);
-
-        // implicit return
-        rb[0]
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         // TODO add error handling for write_register_as_u8()
         let _ = self.i2c_bus.write(da, &[dr, byte]);

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -243,20 +243,6 @@ where
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        for x in values.iter() {
-            match self.i2c_bus.write(da, x) {
-                Ok(_) => {
-                    debug!(
-                        "Successfully wrote register '{0:#04X}' (value: {1:#04X}).",
-                        x[0], x[1]
-                    );
-                }
-                Err(reason) => warn!("Failed to read register '{0:#04X}': {reason:?}", x[0]),
-            }
-        }
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -243,16 +243,6 @@ where
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        let mut buf = [0, 1];
-
-        let res = self.i2c_bus.read(da, &mut buf);
-        match res {
-            Ok(_) => Ok(buf[0]),
-            Err(_) => Err(""),
-        }
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         // TODO add error handling for write_register_as_u8()
         let _ = self.i2c_bus.write(da, &[dr, byte]);

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -229,6 +229,12 @@ where
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -229,10 +229,14 @@ where
         }
     }
 
-    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
-        validate_device_address(da);
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8]) -> Option<[u8; N]> {
+        let mut rb = [0u8; N];
 
-        panic!("read_byte(): function not implemented")
+        // TODO add error handling for read_register_as_u8()
+        let _ = self.i2c_bus.write_read(da, bytes, &mut rb);
+
+        // implicit return
+        Some(rb)
     }
 
     // --------------------------------------------------------------------

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -243,11 +243,6 @@ where
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        // TODO add error handling for write_register_as_u8()
-        let _ = self.i2c_bus.write(da, &[dr, byte]);
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for x in values.iter() {
             match self.i2c_bus.write(da, x) {

--- a/examples/rp2040/src/main.rs
+++ b/examples/rp2040/src/main.rs
@@ -243,10 +243,6 @@ where
         }
     }
 
-    fn write_byte(&mut self, da: u8, byte: u8) {
-        let _ = self.i2c_bus.write(da, &[byte]);
-    }
-
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
         let mut rb = [0u8; 1];
 

--- a/src/emc2101/hw/mod.rs
+++ b/src/emc2101/hw/mod.rs
@@ -38,8 +38,7 @@ pub fn get_manufacturer_id<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Mid as u8)
+    read_register(ibd, DR::Mid as u8)
 }
 
 /// read the product ID
@@ -51,8 +50,7 @@ pub fn get_product_id<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Pid as u8)
+    read_register(ibd, DR::Pid as u8)
 }
 
 /// read the product's revision
@@ -63,8 +61,7 @@ pub fn get_product_revision<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Rev as u8)
+    read_register(ibd, DR::Rev as u8)
 }
 
 /// reset all R/W registers to their default values
@@ -91,7 +88,7 @@ where
         let register = data[0];
         let default = data[1];
 
-        let value = ibd.read_register_as_byte(DEVICE_ADDRESS, register);
+        let value = read_register(ibd, register);
         if default != value {
             warn!("Currently stored and default value for register '{register:#04X}' do not match: {default:#04X} != {value:#04X}");
             is_ok = false;
@@ -109,16 +106,14 @@ pub fn get_status_register<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Status as u8)
+    read_register(ibd, DR::Status as u8)
 }
 
 pub fn get_scratch_register1<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Scratch1 as u8)
+    read_register(ibd, DR::Scratch1 as u8)
 }
 
 pub fn set_scratch_register1<Ibd>(ibd: &mut Ibd, value: u8)
@@ -132,8 +127,7 @@ pub fn get_scratch_register2<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Scratch2 as u8)
+    read_register(ibd, DR::Scratch2 as u8)
 }
 
 pub fn set_scratch_register2<Ibd>(ibd: &mut Ibd, value: u8)
@@ -154,8 +148,7 @@ pub fn get_config_register<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Cfg as u8)
+    read_register(ibd, DR::Cfg as u8)
 }
 
 /// set the device's config register
@@ -209,15 +202,15 @@ pub fn get_tach_reading<Ibd>(ibd: &mut Ibd) -> u16
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let adr = [
-        DR::TachLsb as u8, // low byte, must be read first!
-        DR::TachMsb as u8, // high byte
-    ];
-    let values = ibd.read_multibyte_register_as_u8(DEVICE_ADDRESS, adr);
-    debug!("tach (bytes): {0:#04X} {1:#04X}", values[0], values[1]);
+    // the order is important, low byte must be read first!
+    // (see data sheet section 6.1 for details)
+    let lsb = read_register(ibd, DR::TachLsb as u8);
+    let msb = read_register(ibd, DR::TachMsb as u8);
+
+    debug!("tach (bytes): {0:#04X} {1:#04X}", lsb, msb);
 
     // implicit return
-    u16::from_le_bytes(values)
+    u16::from_le_bytes([lsb, msb])
 }
 
 /// read the fan's speed limit (expressed as "tach reading")
@@ -225,14 +218,11 @@ pub fn get_tach_limit<Ibd>(ibd: &mut Ibd) -> u16
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let adr = [
-        DR::TachLoLsb as u8, // low byte, must be read first!
-        DR::TachLoMsb as u8, // high byte
-    ];
-    let values = ibd.read_multibyte_register_as_u8(DEVICE_ADDRESS, adr);
+    let lsb = read_register(ibd, DR::TachLoLsb as u8);
+    let msb = read_register(ibd, DR::TachLoMsb as u8);
 
     // implicit return
-    u16::from_le_bytes(values)
+    u16::from_le_bytes([lsb, msb])
 }
 
 /// change the fan's speed limit (expressed as "tach reading")
@@ -257,8 +247,7 @@ pub fn get_fan_config<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::FanCfg as u8)
+    read_register(ibd, DR::FanCfg as u8)
 }
 
 /// change the fan config register
@@ -279,8 +268,7 @@ pub fn get_spin_up_behavior<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::FanSpinUp as u8)
+    read_register(ibd, DR::FanSpinUp as u8)
 }
 
 /// change the fan spin up behavior register
@@ -304,8 +292,7 @@ pub fn get_fan_speed<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::FanSpeed as u8)
+    read_register(ibd, DR::FanSpeed as u8)
 }
 
 /// change the fan speed register
@@ -330,8 +317,7 @@ pub fn get_pwm_frequency<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::PwmFrq as u8)
+    read_register(ibd, DR::PwmFrq as u8)
 }
 
 /// change the PWM frequency register
@@ -352,8 +338,7 @@ pub fn get_pwm_frequency_divider<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::PwmFrqDiv as u8)
+    read_register(ibd, DR::PwmFrqDiv as u8)
 }
 
 /// change the PWM frequency divider register
@@ -453,8 +438,7 @@ pub fn get_conversion_rate<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::ConvRate as u8)
+    read_register(ibd, DR::ConvRate as u8)
 }
 
 /// change the temperature conversion rate register
@@ -479,8 +463,7 @@ pub fn get_internal_temperature<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::Its as u8)
+    read_register(ibd, DR::Its as u8)
 }
 
 /// read the "high temperature" alerting limit
@@ -491,8 +474,7 @@ pub fn get_internal_temperature_high_limit<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::ItsHi as u8)
+    read_register(ibd, DR::ItsHi as u8)
 }
 
 /// set the "high temperature" alerting limit
@@ -517,8 +499,7 @@ pub fn get_alert_mask<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::AlrtMsk as u8)
+    read_register(ibd, DR::AlrtMsk as u8)
 }
 
 /// change the alert mask
@@ -538,8 +519,7 @@ pub fn get_ets_bcf<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::EtsBcf as u8)
+    read_register(ibd, DR::EtsBcf as u8)
 }
 
 /// change the external sensor's beta compensation factor
@@ -555,8 +535,7 @@ pub fn get_ets_dif<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::EtsDif as u8)
+    read_register(ibd, DR::EtsDif as u8)
 }
 
 /// change the external sensor's diode ideality factor
@@ -572,8 +551,7 @@ pub fn get_ets_tcrit_threshold<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::CritTemp as u8)
+    read_register(ibd, DR::CritTemp as u8)
 }
 
 /// change the external sensor's critical temperature threshold
@@ -589,8 +567,7 @@ pub fn get_ets_tcrit_hysteresis<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::CritHyst as u8)
+    read_register(ibd, DR::CritHyst as u8)
 }
 
 /// change the external sensor's critical temperature hysteresis
@@ -610,12 +587,10 @@ pub fn get_external_temperature<Ibd>(ibd: &mut Ibd) -> (u8, u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let adr = [
-        DR::EtsMsb as u8, // high byte, must be read first!
-        DR::EtsLsb as u8, // low byte
-    ];
-
-    let [msb, lsb] = ibd.read_multibyte_register_as_u8(DEVICE_ADDRESS, adr);
+    // the order is important, high byte must be read first!
+    // (see data sheet section 6.1 for details)
+    let msb = read_register(ibd, DR::EtsMsb as u8);
+    let lsb = read_register(ibd, DR::EtsLsb as u8);
 
     // implicit return
     (msb, lsb)
@@ -647,12 +622,8 @@ pub fn get_external_temperature_low_limit<Ibd>(ibd: &mut Ibd) -> (u8, u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let adr = [
-        DR::EtsLoMsb as u8, // high byte, must be read first!
-        DR::EtsLoLsb as u8, // low byte
-    ];
-
-    let [msb, lsb] = ibd.read_multibyte_register_as_u8(DEVICE_ADDRESS, adr);
+    let msb = read_register(ibd, DR::EtsLoMsb as u8);
+    let lsb = read_register(ibd, DR::EtsLoLsb as u8);
 
     // implicit return
     (msb, lsb)
@@ -680,12 +651,8 @@ pub fn get_external_temperature_high_limit<Ibd>(ibd: &mut Ibd) -> (u8, u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let adr = [
-        DR::EtsHiMsb as u8, // high byte, must be read first!
-        DR::EtsHiLsb as u8, // low byte
-    ];
-
-    let [msb, lsb] = ibd.read_multibyte_register_as_u8(DEVICE_ADDRESS, adr);
+    let msb = read_register(ibd, DR::EtsHiMsb as u8);
+    let lsb = read_register(ibd, DR::EtsHiLsb as u8);
 
     // implicit return
     (msb, lsb)
@@ -727,8 +694,7 @@ pub fn get_ets_averaging_filter<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::AvgFlt as u8)
+    read_register(ibd, DR::AvgFlt as u8)
 }
 
 /// set the level of digital averaging used for the external diode
@@ -751,8 +717,7 @@ pub fn get_lookup_table_hysteresis<Ibd>(ibd: &mut Ibd) -> u8
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.read_register_as_byte(DEVICE_ADDRESS, DR::LutHyst as u8)
+    read_register(ibd, DR::LutHyst as u8)
 }
 
 /// change the lookup table hysteresis register
@@ -776,8 +741,8 @@ where
     let adr = DR::LutBase as u8;
     for (i, value) in lut.iter_mut().enumerate() {
         let offset = (i as u8) * 2; // 0, 2, 4, .. 14
-        value.0 = ibd.read_register_as_byte(DEVICE_ADDRESS, adr + offset);
-        value.1 = ibd.read_register_as_byte(DEVICE_ADDRESS, adr + offset + 1);
+        value.0 = read_register(ibd, adr + offset);
+        value.1 = read_register(ibd, adr + offset + 1);
     }
 
     // implicit return
@@ -797,5 +762,18 @@ where
         let offset = (i as u8) * 2; // 0, 2, 4, .. 14
         ibd.write_register_as_byte(DEVICE_ADDRESS, adr + offset, value.0);
         ibd.write_register_as_byte(DEVICE_ADDRESS, adr + offset + 1, value.1);
+    }
+}
+
+// ------------------------------------------------------------------------
+
+fn read_register<Ibd>(ibd: &mut Ibd, dr: u8) -> u8
+where
+    Ibd: crate::traits::I2cBusDevice,
+{
+    let result = ibd.write_and_read_bytes::<1>(DEVICE_ADDRESS, &[dr]);
+    match result {
+        Some(x) => x[0],
+        None => 0xFF,
     }
 }

--- a/src/emc2101/hw/mod.rs
+++ b/src/emc2101/hw/mod.rs
@@ -69,11 +69,8 @@ pub fn reset_device_registers<Ibd>(ibd: &mut Ibd)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // TODO perform a single write transaction
-    for data in DEFAULTS.iter() {
-        let register = data[0];
-        let default = data[1];
-        ibd.write_register_as_byte(DEVICE_ADDRESS, register, default);
+    for bytes in DEFAULTS.iter() {
+        let _ = ibd.write_bytes(DEVICE_ADDRESS, bytes);
     }
 }
 
@@ -120,7 +117,7 @@ pub fn set_scratch_register1<Ibd>(ibd: &mut Ibd, value: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::Scratch1 as u8, value);
+    let _ = write_register(ibd, DR::Scratch1 as u8, value);
 }
 
 pub fn get_scratch_register2<Ibd>(ibd: &mut Ibd) -> u8
@@ -134,7 +131,7 @@ pub fn set_scratch_register2<Ibd>(ibd: &mut Ibd, value: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::Scratch2 as u8, value);
+    let _ = write_register(ibd, DR::Scratch2 as u8, value);
 }
 
 // ------------------------------------------------------------------------
@@ -158,8 +155,7 @@ pub fn set_config_register<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    // implicit return
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::Cfg as u8, byte);
+    let _ = write_register(ibd, DR::Cfg as u8, byte);
 }
 
 //     def configure_spinup_behavior(self, spinup_strength: SpinUpStrength, spinup_duration: SpinUpDuration, fast_mode: bool) -> bool:
@@ -233,11 +229,8 @@ where
     let lsb = (tach & 0b1111_1111) as u8;
     let msb = ((tach >> 8) & 0b1111_1111) as u8;
 
-    let values = [
-        [DR::TachLoLsb as u8, lsb], // low byte
-        [DR::TachLoMsb as u8, msb], // high byte
-    ];
-    ibd.write_multibyte_register_as_u8(DEVICE_ADDRESS, values);
+    let _ = write_register(ibd, DR::TachLoLsb as u8, lsb);
+    let _ = write_register(ibd, DR::TachLoMsb as u8, msb);
 }
 
 /// read the fan config register
@@ -258,7 +251,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     let value_clamped = value.clamp(0, 31);
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::FanCfg as u8, value_clamped);
+    let _ = write_register(ibd, DR::FanCfg as u8, value_clamped);
 }
 
 /// read the fan spin up behavior register
@@ -279,7 +272,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     let value_clamped = value.clamp(0, 31);
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::FanSpinUp as u8, value_clamped);
+    let _ = write_register(ibd, DR::FanSpinUp as u8, value_clamped);
 }
 
 /// read the fan speed register
@@ -307,7 +300,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     let value_clamped = value.clamp(0, 31);
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::FanSpeed as u8, value_clamped);
+    let _ = write_register(ibd, DR::FanSpeed as u8, value_clamped);
 }
 
 /// read the PWM frequency register
@@ -328,7 +321,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     let value_clamped = value.clamp(0, 31);
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::PwmFrq as u8, value_clamped);
+    let _ = write_register(ibd, DR::PwmFrq as u8, value_clamped);
 }
 
 /// read the PWM frequency divider register
@@ -348,7 +341,7 @@ pub fn set_pwm_frequency_divider<Ibd>(ibd: &mut Ibd, value: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::PwmFrqDiv as u8, value);
+    let _ = write_register(ibd, DR::PwmFrqDiv as u8, value);
 }
 
 //     def enable_lookup_table(self) -> bool:
@@ -448,7 +441,7 @@ pub fn set_conversion_rate<Ibd>(ibd: &mut Ibd, value: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::ConvRate as u8, value);
+    let _ = write_register(ibd, DR::ConvRate as u8, value);
 }
 
 // ------------------------------------------------------------------------
@@ -485,9 +478,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     if limit <= 85 {
-        ibd.write_register_as_byte(DEVICE_ADDRESS, DR::ItsHi as u8, limit);
-        // implicit return
-        true
+        write_register(ibd, DR::ItsHi as u8, limit)
     } else {
         // implicit return
         false
@@ -507,7 +498,7 @@ pub fn set_alert_mask<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::AlrtMsk as u8, byte);
+    let _ = write_register(ibd, DR::AlrtMsk as u8, byte);
 }
 
 // ------------------------------------------------------------------------
@@ -527,7 +518,7 @@ pub fn set_ets_bcf<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::EtsBcf as u8, byte);
+    let _ = write_register(ibd, DR::EtsBcf as u8, byte);
 }
 
 /// read the external sensor's diode ideality factor
@@ -543,7 +534,7 @@ pub fn set_ets_dif<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::EtsDif as u8, byte);
+    let _ = write_register(ibd, DR::EtsDif as u8, byte);
 }
 
 /// read the external sensor's critical temperature threshold
@@ -559,7 +550,7 @@ pub fn set_ets_tcrit_threshold<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::CritTemp as u8, byte);
+    let _ = write_register(ibd, DR::CritTemp as u8, byte);
 }
 
 /// read the external sensor's critical temperature hysteresis
@@ -575,7 +566,7 @@ pub fn set_ets_tcrit_hysteresis<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::CritHyst as u8, byte);
+    let _ = write_register(ibd, DR::CritHyst as u8, byte);
 }
 
 /// read the temperature measured by the external sensor
@@ -611,7 +602,7 @@ pub fn set_external_temperature_override<Ibd>(ibd: &mut Ibd, value: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::EtsFrc as u8, value);
+    let _ = write_register(ibd, DR::EtsFrc as u8, value);
 }
 
 /// read the "low temperature" alerting limit
@@ -636,11 +627,10 @@ pub fn set_external_temperature_low_limit<Ibd>(ibd: &mut Ibd, bytes: (u8, u8))
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let values = [
-        [DR::EtsLoMsb as u8, bytes.0], // high byte
-        [DR::EtsLoLsb as u8, bytes.1], // low byte
-    ];
-    ibd.write_multibyte_register_as_u8(DEVICE_ADDRESS, values);
+    let (msb, lsb) = bytes;
+
+    let _ = write_register(ibd, DR::EtsLoMsb as u8, msb);
+    let _ = write_register(ibd, DR::EtsLoLsb as u8, lsb);
 }
 
 /// read the "high temperature" alerting limit
@@ -665,11 +655,10 @@ pub fn set_external_temperature_high_limit<Ibd>(ibd: &mut Ibd, bytes: (u8, u8))
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    let values = [
-        [DR::EtsHiMsb as u8, bytes.0], // high byte
-        [DR::EtsHiLsb as u8, bytes.1], // low byte
-    ];
-    ibd.write_multibyte_register_as_u8(DEVICE_ADDRESS, values);
+    let (msb, lsb) = bytes;
+
+    let _ = write_register(ibd, DR::EtsHiMsb as u8, msb);
+    let _ = write_register(ibd, DR::EtsHiLsb as u8, lsb);
 }
 
 /// trigger a temperature conversion ('one shot')
@@ -681,9 +670,7 @@ where
 {
     // the write operation is the important part
     // (the data value is irrelevant and ignored)
-
-    // implicit return
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::OneShot as u8, 0x00)
+    let _ = write_register(ibd, DR::OneShot as u8, 0x00);
 }
 
 /// get the level of digital averaging used for the external diode
@@ -705,7 +692,7 @@ pub fn set_ets_averaging_filter<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::AvgFlt as u8, byte);
+    let _ = write_register(ibd, DR::AvgFlt as u8, byte);
 }
 
 // ------------------------------------------------------------------------
@@ -725,7 +712,7 @@ pub fn set_lookup_table_hysteresis<Ibd>(ibd: &mut Ibd, byte: u8)
 where
     Ibd: crate::traits::I2cBusDevice,
 {
-    ibd.write_register_as_byte(DEVICE_ADDRESS, DR::LutHyst as u8, byte);
+    let _ = write_register(ibd, DR::LutHyst as u8, byte);
 }
 
 /// read the lookup table registers
@@ -760,8 +747,8 @@ where
     let adr = DR::LutBase as u8;
     for (i, value) in lut.iter().enumerate() {
         let offset = (i as u8) * 2; // 0, 2, 4, .. 14
-        ibd.write_register_as_byte(DEVICE_ADDRESS, adr + offset, value.0);
-        ibd.write_register_as_byte(DEVICE_ADDRESS, adr + offset + 1, value.1);
+        let _ = write_register(ibd, adr + offset, value.0);
+        let _ = write_register(ibd, adr + offset + 1, value.1);
     }
 }
 
@@ -776,4 +763,11 @@ where
         Some(x) => x[0],
         None => 0xFF,
     }
+}
+
+fn write_register<Ibd>(ibd: &mut Ibd, dr: u8, rv: u8) -> bool
+where
+    Ibd: crate::traits::I2cBusDevice,
+{
+    ibd.write_bytes(DEVICE_ADDRESS, &[dr, rv])
 }

--- a/src/ht16k33/hw/mod.rs
+++ b/src/ht16k33/hw/mod.rs
@@ -52,7 +52,7 @@ where
             "Setting oscillator mode on {0:#04X} to {1:#04X}.",
             da, value
         );
-        ibd.write_byte(da, value);
+        ibd.write_bytes(da, &[value]);
         true
     } else {
         error!("Oscillator mode must be in range 0 ≤ x ≤ 1");
@@ -100,7 +100,7 @@ where
     if value <= 15 {
         let value = 0x80 | value;
         debug!("Setting blink rate on {0:#04X} to {1:#04X}.", da, value);
-        ibd.write_byte(da, value);
+        ibd.write_bytes(da, &[value]);
         true
     } else {
         error!("Blink rate must be in range 0 ≤ x ≤ 15");
@@ -123,7 +123,7 @@ where
     Ibd: crate::traits::I2cBusDevice,
 {
     if value <= 3 {
-        ibd.write_byte(da, 0xA0 | value);
+        ibd.write_bytes(da, &[0xA0 | value]);
         true
     } else {
         error!("Output pin select must be in range 0 ≤ x ≤ 3");
@@ -155,7 +155,7 @@ where
             "Setting brightness level on {0:#04X} to {1:#04X}.",
             da, value
         );
-        ibd.write_byte(da, value);
+        ibd.write_bytes(da, &[value]);
         true
     } else {
         error!("Brightness level must be in range 0 ≤ x ≤ 15");

--- a/src/i2c_helpers.rs
+++ b/src/i2c_helpers.rs
@@ -2,7 +2,7 @@
     common I²C-related functions
 */
 
-use core::result::Result::{Err, Ok};
+use core::option::Option::{None, Some};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, warn};
@@ -21,17 +21,17 @@ where
     // the I²C bus master is always present (address 0)
     d[0] = true;
 
-    for addr in 1..=127u8 {
-        debug!("Scanning for I²C device at address {addr}.");
+    for da in 1..=127u8 {
+        debug!("Scanning for I²C device at address {da}.");
 
-        let res = ibd.read_byte(addr);
+        let res = ibd.read_bytes::<1>(da);
         match res {
-            Ok(_) => {
-                d[addr as usize] = true;
-                debug!("Found an I²C device at address {addr}.");
+            Some(_) => {
+                d[da as usize] = true;
+                debug!("Found an I²C device at address {da}.");
             }
-            Err(_) => {
-                debug!("Unable to find a device at address {addr}.");
+            None => {
+                debug!("Unable to find a device at address {da}.");
             }
         }
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,6 +19,13 @@ pub trait I2cBusDevice {
     /// returns true if the write succeeded and false if the write fails
     fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool;
 
+    /// write the specified number of bytes to the I²C device and then
+    /// read the specified number of bytes from the I²C device
+    ///
+    /// returns the specified number of bytes if the read succeeded or a
+    /// null value if the write failed
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8]) -> Option<[u8; N]>;
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -49,10 +49,6 @@ pub trait I2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    /// write a single byte to device register 'dr'
-    /// TODO deprecate method 'write_register_as_byte()'
-    fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8);
-
     /// write two independent registers in the exact order provided
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,17 +10,36 @@ use core::result::Result;
 pub trait I2cBusDevice {
     /// read the specified number of bytes from the I²C device
     ///
+    /// ```TEXT
+    /// # read two bytes from device with address 0x42:
+    /// let result = dh.read_bytes::<2>(0x42);
+    /// ```
+    ///
     /// returns the specified number of bytes if the read succeeded or a
     /// null value if the write failed
     fn read_bytes<const N: usize>(&mut self, _da: u8) -> Option<[u8; N]>;
 
     /// write the specified number of bytes to the I²C device
     ///
+    /// ```TEXT
+    /// # write two bytes to device with address 0x42:
+    /// #   or
+    /// # write one byte to device with address 0x42 and 'register' 0x13:
+    /// let is_success = dh.write_bytes(0x43, &[0x13, 0x02]);
+    /// ```
+    ///
     /// returns true if the write succeeded and false if the write fails
     fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool;
 
     /// write the specified number of bytes to the I²C device and then
     /// read the specified number of bytes from the I²C device
+    /// - typically used to select a 'register' and then read data
+    /// - writing to this 'register' can be done via write_bytes()
+    ///
+    /// ```TEXT
+    /// # read two bytes from device with address 0x42 and 'register' 0x13:
+    /// let result = dh.write_and_read_bytes::<2>(0x42, &[0x13]);
+    /// ```
     ///
     /// returns the specified number of bytes if the read succeeded or a
     /// null value if the write failed

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,7 @@
     public traits
 */
 
-use core::result::Result;
+use core::option::Option;
 
 // TODO provide device-agnostic error types (enum?)
 
@@ -48,9 +48,6 @@ pub trait I2cBusDevice {
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------
-
-    /// read a single byte
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str>;
 
     /// write a single byte to device register 'dr'
     /// TODO deprecate method 'write_register_as_byte()'

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -53,11 +53,6 @@ pub trait I2cBusDevice {
     /// TODO deprecate method 'write_register_as_byte()'
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8);
 
-    /// read multiple independent registers in the exact order provided
-    ///
-    /// returns the register's values in exactly the same order
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N];
-
     /// write two independent registers in the exact order provided
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -49,9 +49,6 @@ pub trait I2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    /// write two independent registers in the exact order provided
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]);
-
     // some functions require a little time to pass
     // the sleep function is hardware-dependent and must be provided by
     // the caller

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,12 +26,6 @@ pub trait I2cBusDevice {
     /// read a single byte
     fn read_byte(&mut self, da: u8) -> Result<u8, &'static str>;
 
-    /// send a single byte
-    ///
-    /// this function is useful for devices that combine the 'register' and
-    /// the 'data' into a single byte, e.g. Holtek HT16K33
-    fn write_byte(&mut self, da: u8, byte: u8);
-
     /// read a single byte from device register 'dr'
     /// TODO deprecate method 'write_register_as_byte(read_register_as_byte)'
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -52,10 +52,6 @@ pub trait I2cBusDevice {
     /// read a single byte
     fn read_byte(&mut self, da: u8) -> Result<u8, &'static str>;
 
-    /// read a single byte from device register 'dr'
-    /// TODO deprecate method 'write_register_as_byte(read_register_as_byte)'
-    fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8;
-
     /// write a single byte to device register 'dr'
     /// TODO deprecate method 'write_register_as_byte()'
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8);

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("read_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -30,6 +30,12 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("write_register_as_byte(): function not implemented")
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        panic!("read_multibyte_register_as_u8(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_byte(): function not implemented");
-    }
-
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_register_as_byte(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        panic!("write_multibyte_register_as_u8(): function not implemented")
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/aht10/common/mod.rs
+++ b/tests/aht10/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
-        validate_device_address(da);
-
-        panic!("read_register_as_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("read_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -30,6 +30,12 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("write_register_as_byte(): function not implemented")
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        panic!("read_multibyte_register_as_u8(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_byte(): function not implemented");
-    }
-
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_register_as_byte(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        panic!("write_multibyte_register_as_u8(): function not implemented")
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/aht20/common/mod.rs
+++ b/tests/aht20/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
-        validate_device_address(da);
-
-        panic!("read_register_as_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("read_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -30,6 +30,12 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("write_register_as_byte(): function not implemented")
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        panic!("read_multibyte_register_as_u8(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_byte(): function not implemented");
-    }
-
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("write_register_as_byte(): function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -40,12 +40,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        panic!("write_multibyte_register_as_u8(): function not implemented")
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/ahtx0_hw/common/mod.rs
+++ b/tests/ahtx0_hw/common/mod.rs
@@ -46,12 +46,6 @@ impl i2c_devices::I2cBusDevice for VirtualAHTx0 {
         panic!("read_byte(): function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
-        validate_device_address(da);
-
-        panic!("read_register_as_byte(): function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -34,10 +34,18 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         }
     }
 
-    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8]) -> Option<[u8; N]> {
         validate_device_address(da);
 
-        panic!("read_byte(): function not implemented")
+        // always 1 byte for EMC2101 / EMC2101-R
+        if bytes.len() == 1 {
+            let dr = bytes[0];
+            let mut result = [0x00; N];
+            result[0] = self.registers[dr as usize].0;
+            Some(result)
+        } else {
+            panic!("write_and_read_bytes(): must write exactly one byte")
+        }
     }
 
     // --------------------------------------------------------------------
@@ -51,9 +59,7 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        validate_device_address(da);
-
-        self.registers[dr as usize].0
+        self.write_and_read_bytes::<1>(da, &[dr]).unwrap()[0]
     }
 
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -58,10 +58,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        self.write_and_read_bytes::<1>(da, &[dr]).unwrap()[0]
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         self.write_bytes(da, &[dr, byte]);
     }

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -16,10 +16,22 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn write_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8; N]) -> bool {
+    fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool {
         validate_device_address(da);
 
-        panic!("function not implemented")
+        if bytes.len() == 2 {
+            let dr = bytes[0]; // device register
+            let rv = bytes[1]; // register value
+            if self.registers[dr as usize].1 {
+                self.registers[dr as usize].0 = rv;
+                true
+            } else {
+                panic!("attempted write to read-only register {dr:#02X}")
+            }
+        } else {
+            // too many bytes (expect exactly 2 for all EMC2101 writes)
+            false
+        }
     }
 
     // --------------------------------------------------------------------
@@ -45,13 +57,7 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        validate_device_address(da);
-
-        if self.registers[dr as usize].1 {
-            self.registers[dr as usize].0 = byte;
-        } else {
-            panic!("attempted write to read-only register {dr:#02X}")
-        }
+        self.write_bytes(da, &[dr, byte]);
     }
 
     fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
@@ -68,17 +74,8 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        for x in values.iter() {
-            let dr = x[0];
-            let dv = x[1];
-
-            if self.registers[dr as usize].1 {
-                self.registers[dr as usize].0 = dv;
-            } else {
-                panic!("attempted write to read-only register {dr:#02X}")
-            }
+        for bytes in values.iter() {
+            self.write_bytes(da, bytes);
         }
     }
 

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -44,12 +44,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -52,10 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        self.write_bytes(da, &[dr, byte]);
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for bytes in values.iter() {
             self.write_bytes(da, bytes);

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -52,12 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        for bytes in values.iter() {
-            self.write_bytes(da, bytes);
-        }
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -52,12 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         self.write_bytes(da, &[dr, byte]);
     }

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -34,6 +34,12 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/emc2101/common/mod.rs
+++ b/tests/emc2101/common/mod.rs
@@ -56,19 +56,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         self.write_bytes(da, &[dr, byte]);
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        let mut rb = [0u8; N];
-
-        for (i, register) in dr.iter().enumerate() {
-            rb[i] = self.registers[*register as usize].0;
-        }
-
-        // implicit return
-        rb
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for bytes in values.iter() {
             self.write_bytes(da, bytes);

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -34,10 +34,18 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         }
     }
 
-    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8]) -> Option<[u8; N]> {
         validate_device_address(da);
 
-        panic!("read_byte(): function not implemented")
+        // always 1 byte for EMC2101 / EMC2101-R
+        if bytes.len() == 1 {
+            let dr = bytes[0];
+            let mut result = [0x00; N];
+            result[0] = self.registers[dr as usize].0;
+            Some(result)
+        } else {
+            panic!("write_and_read_bytes(): must write exactly one byte")
+        }
     }
 
     // --------------------------------------------------------------------
@@ -51,9 +59,7 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        validate_device_address(da);
-
-        self.registers[dr as usize].0
+        self.write_and_read_bytes::<1>(da, &[dr]).unwrap()[0]
     }
 
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -58,10 +58,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
-        self.write_and_read_bytes::<1>(da, &[dr]).unwrap()[0]
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         self.write_bytes(da, &[dr, byte]);
     }

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -16,10 +16,22 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn write_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8; N]) -> bool {
+    fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool {
         validate_device_address(da);
 
-        panic!("function not implemented")
+        if bytes.len() == 2 {
+            let dr = bytes[0]; // device register
+            let rv = bytes[1]; // register value
+            if self.registers[dr as usize].1 {
+                self.registers[dr as usize].0 = rv;
+                true
+            } else {
+                panic!("attempted write to read-only register {dr:#02X}")
+            }
+        } else {
+            // too many bytes (expect exactly 2 for all EMC2101 writes)
+            false
+        }
     }
 
     // --------------------------------------------------------------------
@@ -45,13 +57,7 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        validate_device_address(da);
-
-        if self.registers[dr as usize].1 {
-            self.registers[dr as usize].0 = byte;
-        } else {
-            panic!("attempted write to read-only register {dr:#02X}")
-        }
+        self.write_bytes(da, &[dr, byte]);
     }
 
     fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
@@ -68,17 +74,8 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     }
 
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        for x in values.iter() {
-            let dr = x[0];
-            let dv = x[1];
-
-            if self.registers[dr as usize].1 {
-                self.registers[dr as usize].0 = dv;
-            } else {
-                panic!("attempted write to read-only register {dr:#02X}")
-            }
+        for bytes in values.iter() {
+            self.write_bytes(da, bytes);
         }
     }
 

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -44,12 +44,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         panic!("function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn read_register_as_byte(&mut self, da: u8, dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -52,10 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
-        self.write_bytes(da, &[dr, byte]);
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for bytes in values.iter() {
             self.write_bytes(da, bytes);

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -52,12 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
-        for bytes in values.iter() {
-            self.write_bytes(da, bytes);
-        }
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -52,12 +52,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, dr: u8, byte: u8) {
         self.write_bytes(da, &[dr, byte]);
     }

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -34,6 +34,12 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/emc2101_hw/common/mod.rs
+++ b/tests/emc2101_hw/common/mod.rs
@@ -56,19 +56,6 @@ impl i2c_devices::I2cBusDevice for VirtualI2cBusDevice {
         self.write_bytes(da, &[dr, byte]);
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        let mut rb = [0u8; N];
-
-        for (i, register) in dr.iter().enumerate() {
-            rb[i] = self.registers[*register as usize].0;
-        }
-
-        // implicit return
-        rb
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, values: [[u8; 2]; N]) {
         for bytes in values.iter() {
             self.write_bytes(da, bytes);

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -75,12 +75,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -20,27 +20,42 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool {
         validate_device_address(da);
 
-        // validate the first byte, copy the remaining 16
-        if bytes[0] == 0x00 {
-            self.dda[0] = bytes[1];
-            self.dda[1] = bytes[2];
-            self.dda[2] = bytes[3];
-            self.dda[3] = bytes[4];
-            self.dda[4] = bytes[5];
-            self.dda[5] = bytes[6];
-            self.dda[6] = bytes[7];
-            self.dda[7] = bytes[8];
-            self.dda[8] = bytes[9];
-            self.dda[9] = bytes[10];
-            self.dda[10] = bytes[11];
-            self.dda[11] = bytes[12];
-            self.dda[12] = bytes[13];
-            self.dda[13] = bytes[14];
-            self.dda[14] = bytes[15];
-            self.dda[15] = bytes[16];
+        if bytes.len() == 1 {
+            let register = bytes[0] & 0xF0;
+            let value = bytes[0] & 0x0F;
+            match register {
+                0x20 => self.osc = value,
+                0x80 => self.dis = value,
+                0xA0 => self.ris = value,
+                0xE0 => self.dim = value,
+                _ => panic!("invalid register"),
+            }
             true
+        } else if bytes.len() == 17 {
+            // validate the first byte, copy the remaining 16
+            if bytes[0] == 0x00 {
+                self.dda[0] = bytes[1];
+                self.dda[1] = bytes[2];
+                self.dda[2] = bytes[3];
+                self.dda[3] = bytes[4];
+                self.dda[4] = bytes[5];
+                self.dda[5] = bytes[6];
+                self.dda[6] = bytes[7];
+                self.dda[7] = bytes[8];
+                self.dda[8] = bytes[9];
+                self.dda[9] = bytes[10];
+                self.dda[10] = bytes[11];
+                self.dda[11] = bytes[12];
+                self.dda[12] = bytes[13];
+                self.dda[13] = bytes[14];
+                self.dda[14] = bytes[15];
+                self.dda[15] = bytes[16];
+                true
+            } else {
+                panic!("invalid write")
+            }
         } else {
-            panic!("invalid write")
+            panic!("invalid byte length")
         }
     }
 
@@ -55,17 +70,7 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     }
 
     fn write_byte(&mut self, da: u8, byte: u8) {
-        validate_device_address(da);
-
-        let register = byte & 0xF0;
-        let value = byte & 0x0F;
-        match register {
-            0x20 => self.osc = value,
-            0x80 => self.dis = value,
-            0xA0 => self.ris = value,
-            0xE0 => self.dim = value,
-            _ => panic!("invalid register"),
-        }
+        self.write_bytes(da, &[byte]);
     }
 
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
@@ -90,16 +95,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         validate_device_address(da);
 
         panic!("function not implemented")
-        // for x in values.iter() {
-        //     let dr = x[0];
-        //     let dv = x[1];
-
-        //     if self.registers[dr as usize].1 {
-        //         self.registers[dr as usize].0 = dv;
-        //     } else {
-        //         panic!("attempted write to read-only register {dr:#02X}")
-        //     }
-        // }
     }
 
     // some hardware functions require a little time to pass

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -75,12 +75,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -69,10 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, byte: u8) {
-        self.write_bytes(da, &[byte]);
-    }
-
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/ht16k33/common/mod.rs
+++ b/tests/ht16k33/common/mod.rs
@@ -59,6 +59,12 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn read_byte(&mut self, da: u8) -> Result<u8, &'static str> {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -75,12 +75,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn read_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _dr: [u8; N]) -> [u8; N] {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
         validate_device_address(da);
 

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -69,12 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     // to refactor
     // --------------------------------------------------------------------
 
-    fn write_multibyte_register_as_u8<const N: usize>(&mut self, da: u8, _values: [[u8; 2]; N]) {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     // some hardware functions require a little time to pass
     // - functions that sleep mention this fact in their documentation
     // - sleeping is hardware-dependent, no_std provides no abstraction

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -20,27 +20,42 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     fn write_bytes<const N: usize>(&mut self, da: u8, bytes: &[u8; N]) -> bool {
         validate_device_address(da);
 
-        // validate the first byte, copy the remaining 16
-        if bytes[0] == 0x00 {
-            self.dda[0] = bytes[1];
-            self.dda[1] = bytes[2];
-            self.dda[2] = bytes[3];
-            self.dda[3] = bytes[4];
-            self.dda[4] = bytes[5];
-            self.dda[5] = bytes[6];
-            self.dda[6] = bytes[7];
-            self.dda[7] = bytes[8];
-            self.dda[8] = bytes[9];
-            self.dda[9] = bytes[10];
-            self.dda[10] = bytes[11];
-            self.dda[11] = bytes[12];
-            self.dda[12] = bytes[13];
-            self.dda[13] = bytes[14];
-            self.dda[14] = bytes[15];
-            self.dda[15] = bytes[16];
+        if bytes.len() == 1 {
+            let register = bytes[0] & 0xF0;
+            let value = bytes[0] & 0x0F;
+            match register {
+                0x20 => self.osc = value,
+                0x80 => self.dis = value,
+                0xA0 => self.ris = value,
+                0xE0 => self.dim = value,
+                _ => panic!("invalid register"),
+            }
             true
+        } else if bytes.len() == 17 {
+            // validate the first byte, copy the remaining 16
+            if bytes[0] == 0x00 {
+                self.dda[0] = bytes[1];
+                self.dda[1] = bytes[2];
+                self.dda[2] = bytes[3];
+                self.dda[3] = bytes[4];
+                self.dda[4] = bytes[5];
+                self.dda[5] = bytes[6];
+                self.dda[6] = bytes[7];
+                self.dda[7] = bytes[8];
+                self.dda[8] = bytes[9];
+                self.dda[9] = bytes[10];
+                self.dda[10] = bytes[11];
+                self.dda[11] = bytes[12];
+                self.dda[12] = bytes[13];
+                self.dda[13] = bytes[14];
+                self.dda[14] = bytes[15];
+                self.dda[15] = bytes[16];
+                true
+            } else {
+                panic!("invalid write")
+            }
         } else {
-            panic!("invalid write")
+            panic!("invalid byte length")
         }
     }
 
@@ -55,17 +70,7 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
     }
 
     fn write_byte(&mut self, da: u8, byte: u8) {
-        validate_device_address(da);
-
-        let register = byte & 0xF0;
-        let value = byte & 0x0F;
-        match register {
-            0x20 => self.osc = value,
-            0x80 => self.dis = value,
-            0xA0 => self.ris = value,
-            0xE0 => self.dim = value,
-            _ => panic!("invalid register"),
-        }
+        self.write_bytes(da, &[byte]);
     }
 
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
@@ -90,16 +95,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         validate_device_address(da);
 
         panic!("function not implemented")
-        // for x in values.iter() {
-        //     let dr = x[0];
-        //     let dv = x[1];
-
-        //     if self.registers[dr as usize].1 {
-        //         self.registers[dr as usize].0 = dv;
-        //     } else {
-        //         panic!("attempted write to read-only register {dr:#02X}")
-        //     }
-        // }
     }
 
     // some hardware functions require a little time to pass

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -75,12 +75,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
-        validate_device_address(da);
-
-        panic!("function not implemented")
-    }
-
     fn write_register_as_byte(&mut self, da: u8, _dr: u8, _byte: u8) {
         validate_device_address(da);
 

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -69,10 +69,6 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         panic!("function not implemented")
     }
 
-    fn write_byte(&mut self, da: u8, byte: u8) {
-        self.write_bytes(da, &[byte]);
-    }
-
     fn read_register_as_byte(&mut self, da: u8, _dr: u8) -> u8 {
         validate_device_address(da);
 

--- a/tests/ht16k33_hw/common/mod.rs
+++ b/tests/ht16k33_hw/common/mod.rs
@@ -59,6 +59,12 @@ impl i2c_devices::I2cBusDevice for VirtualHt16K33 {
         }
     }
 
+    fn write_and_read_bytes<const N: usize>(&mut self, da: u8, _bytes: &[u8]) -> Option<[u8; N]> {
+        validate_device_address(da);
+
+        panic!("read_byte(): function not implemented")
+    }
+
     // --------------------------------------------------------------------
     // to refactor
     // --------------------------------------------------------------------


### PR DESCRIPTION
## Rationale

The existing six functions of trait `I2cBusDevice` can be replaced by three
generalized functions. This reduces the implementation effort for users of
this library while simultaneously offering more flexibility in their usage.

The three functions have been chosen to align with the functions
typically exposed by the hardware-specific I²C bus drivers:

| trait                      | esp_hal (ESP32)  | rp_hal (RP2040)  | 
|:-------------------------- |:---------------- | ---------------- |
| ibd.read_bytes()           | i2c.read()       | i2c.read()       |
| ibd.write_bytes()          | i2c.write()      | i2c.write()      |
| ibd.write_and_read_bytes() | i2c.write_read() | i2c.write_read() |

## Usage

reading and writing byte sequences

```RUST
# read two bytes from device with address 0x42:
let result = dh.read_bytes::<2>(0x42);

# write two bytes to device with address 0x42:
let is_success = dh.write_bytes(0x43, &[0x01, 0x02]);
```

reading and writing to a 'register'

```RUST
# read two bytes from 'register' 0x13:
let result = dh.write_and_read_bytes::<2>(0x42, &[0x13]);

# write two bytes to 'register' 0x13:
let is_success = dh.write_bytes(0x43, &[0x13, 0x01, 0x02]);
```

_The term 'register' is not an official term. Reading and writing to a CPU
register has a similar semantics and that's the reason for this naming._

## Deprecations

The following functions have been deprecated and removed from the trait:

- `read_byte()`
- `write_byte()`
- `read_register_as_byte()`
- `write_register_as_byte()`
- `read_multibyte_register_as_u8()`
- `write_multibyte_register_as_u8()`